### PR TITLE
Please add RelViT (ICLR 2022)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Markdown format:
      * [2022](#2022)
         - [ACL 2022](#ACL-2022)
         - [CVPR 2022](#CVPR-2022)
+        - [ICLR 2022](#ICLR-2022)
         - [AAAI 2022](#AAAI-2022)
         - [IJCAI 2022](#IJCAI-2022)
      * [2021](#2021)
@@ -97,6 +98,11 @@ Markdown format:
 - [MuKEA: Multimodal Knowledge Extraction and Accumulation for Knowledge-based Visual Question Answering](https://arxiv.org/abs/2203.09138) - Yang Ding et al, **CVPR 2022**. [[code]](https://github.com/AndersonStra/MuKEA)
 - [Grounding Answers for Visual Questions Asked by Visually Impaired People](https://arxiv.org/abs/2202.01993) - Choyan Chen et al, **CVPR 2022**. [[page]](https://vizwiz.org/tasks-and-datasets/answer-grounding-for-vqa/)
 - [Maintaining Reasoning Consistency in Compositional Visual Question Answering](https://jingchenchen.github.io/files/papers/2022/CVPR_DLR.pdf) - Chenchen Jing et al, **CVPR 2022**. [[code]](https://github.com/jingchenchen/ReasoningConsistency-VQA)
+
+#### ICLR 2022
+
+- [RelViT: Concept-guided Vision Transformer for Visual Relational Reasoning](https://arxiv.org/abs/2204.11167) - Xiaojian Ma et al, **ICLR 2022**. [[code]](https://github.com/NVlabs/RelViT)
+
 
 #### AAAI 2022
 


### PR DESCRIPTION
Hi,

Thanks for making this learning list and indeed I learned a lot. Just want to share one of our recent works on VQA and I hope it could help the community through your platform:

RelViT: Concept-guided Vision Transformer for Visual Relational Reasoning (ICLR 2022)
[arxiv](https://arxiv.org/abs/2204.11167) | [code](https://github.com/NVlabs/RelViT)
In this work, we propose a better training scheme for vision transformers and testify it on VQA, HOI, and visual reasoning tasks. We further introduce concept-guided contrastive learning that helps these models master visual reasoning without massive pertaining or extra training data.